### PR TITLE
[GLUE] Add missing quote to Glue example

### DIFF
--- a/website/docs/r/glue_crawler.html.markdown
+++ b/website/docs/r/glue_crawler.html.markdown
@@ -36,7 +36,7 @@ resource "aws_glue_crawler" "example" {
   role          = "${aws_iam_role.example.name}"
 
   s3_target {
-    path = "s3://${aws_s3_bucket.example.bucket}
+    path = "s3://${aws_s3_bucket.example.bucket}"
   }
 }
 ```


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #0000

Changes proposed in this pull request:

* Change 1
* Change 2

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSAvailabilityZones'

...
```
